### PR TITLE
fix: 道路データのLINESTRING抽出処理を堅牢化し，AGR指定を修正

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pavement
 Title: Analyzing Spatial Events on Roadways
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c( 
     person("Keisuke", "ANDO",
            email   = "ando@maslab.aitech.ac.jp",

--- a/R/fetch-roads.R
+++ b/R/fetch-roads.R
@@ -281,7 +281,9 @@ determine_crop_area <- function(params) {
 
 # Convert MULTILINESTRING to LINESTRING and generate unique IDs
 convert_multilinestring_to_linestring <- function(roads) {
-  roads_agr  <- sf::st_set_agr(roads, "constrant")
+  roads_extracted <- sf::st_collection_extract(roads, "LINESTRING")
+
+  roads_agr  <- sf::st_set_agr(roads_extracted, "constant")
   roads_cast <- sf::st_cast(roads_agr, "LINESTRING")
 
   roads_cast$id <- sprintf("rd_%04x", seq_len(nrow(roads_cast)))


### PR DESCRIPTION
- `st_collection_extract(roads, "LINESTRING")`を追加し，GEOMETRYCOLLECTIONやMULTILINESTRINGを安全に処理できるように変更
- AGR指定の誤字`"constrant"`を`"constant"`に修正

これにより，`st_cast` 実行時に発生していた「最初の線分のみ保持される」警告を防止し，データ欠損リスクを回避